### PR TITLE
fixing dockerfile for deployment

### DIFF
--- a/api_Dockerfile
+++ b/api_Dockerfile
@@ -23,4 +23,5 @@ ENV PYTHONPATH=/sim-engine-api
 # The port will be set by Railway
 EXPOSE ${PORT:-3001}
 
-CMD ["python", "api/run.py"]
+# Use the full path to run.py
+CMD ["python", "/sim-engine-api/api/run.py"]


### PR DESCRIPTION
This pull request updates the `CMD` instruction in the `api_Dockerfile` to use the full path for the `run.py` script, ensuring the script is executed correctly in the Docker container.

* [`api_Dockerfile`](diffhunk://#diff-d3062a9fac564d0c5bbee488705475287bdd1cef592e4cf29e2ecdc66d630935L26-R27): Updated the `CMD` instruction to specify the full path to `run.py` (`/sim-engine-api/api/run.py`) for improved clarity and reliability.