### PR TITLE
Refactor Dockerfile to use Flask command for application startup

### DIFF
--- a/api_Dockerfile
+++ b/api_Dockerfile
@@ -15,17 +15,14 @@ COPY . .
 RUN pip install --no-cache-dir -r requirements.txt
 RUN pip install -e .
 
-# Create a shell script to run the application
-RUN echo '#!/bin/bash\ncd /sim-engine-api\npython api/run.py' > /sim-engine-api/run.sh
-RUN chmod +x /sim-engine-api/run.sh
-
 # Set environment variables
 ENV FLASK_ENV=production
+ENV FLASK_APP=api.run:app
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/sim-engine-api
 
 # The port will be set by Railway
 EXPOSE ${PORT:-3001}
 
-# Use the shell script to run the application
-CMD ["/sim-engine-api/run.sh"]
+# Use flask command to run the application
+CMD ["flask", "run", "--host=0.0.0.0"]


### PR DESCRIPTION
This pull request updates the `api_Dockerfile` to simplify the application startup process by removing a custom shell script and directly using Flask's built-in command for running the application.

**Dockerfile changes:**
* Removed the creation and use of a custom shell script (`run.sh`) for starting the application.
* Added the `FLASK_APP` environment variable to specify the application entry point (`api.run:app`).
* Updated the `CMD` instruction to use the `flask run` command with the `--host=0.0.0.0` option, allowing the application to be accessible externally.