### PR TITLE
Add import for nfl_simulation_engine_lite in run.py

### DIFF
--- a/api/run.py
+++ b/api/run.py
@@ -1,4 +1,5 @@
 from api.app import create_app
+from nfl_simulation_engine_lite import *
 import os
 
 app = create_app()


### PR DESCRIPTION
This pull request introduces a small change to the `api/run.py` file. It adds a wildcard import for the `nfl_simulation_engine_lite` module, potentially to use its contents within the application.