### PR TITLE
Update Procfile to use Gunicorn for prod deployment and added Gunicor…

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python -m api.run 
+web: gunicorn --bind 0.0.0.0:$PORT api.run:app 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ click==8.1.8
 Flask==3.1.0
 Flask-Cors==5.0.0
 Flask-Limiter==3.5.0
+gunicorn==21.2.0
 limits==3.7.0
 idna==3.10
 iniconfig==2.0.0


### PR DESCRIPTION
This pull request updates the `Procfile` to improve the deployment configuration by switching the web server from the default Python module runner to Gunicorn, a production-grade WSGI server.

Deployment configuration update:

* [`Procfile`](diffhunk://#diff-0a99231995da379e7aebabe76c9d849a23737a42c3b3a8994043e2aa80958424L1-R1): Replaced the command to run the application from `python -m api.run` to `gunicorn --bind 0.0.0.0:$PORT api.run:app`, which enhances performance and reliability for production environments.